### PR TITLE
Devel

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: systemPipeR
 Type: Package
 Title: systemPipeR: NGS workflow and report generation environment
-Version: 1.21.6
-Date: 2020-03-30
+Version: 1.21.7
+Date: 2020-04-18
 Author: Thomas Girke
 Maintainer: Thomas Girke <thomas.girke@ucr.edu>
 biocViews: Genetics, Infrastructure, DataImport, Sequencing, RNASeq, RiboSeq, ChIPSeq, MethylSeq, SNP, GeneExpression, Coverage, GeneSetEnrichment, Alignment, QualityControl, ImmunoOncology

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: systemPipeR
 Type: Package
 Title: systemPipeR: NGS workflow and report generation environment
-Version: 1.21.7
-Date: 2020-04-18
+Version: 1.21.8
+Date: 2020-04-21
 Author: Thomas Girke
 Maintainer: Thomas Girke <thomas.girke@ucr.edu>
 biocViews: Genetics, Infrastructure, DataImport, Sequencing, RNASeq, RiboSeq, ChIPSeq, MethylSeq, SNP, GeneExpression, Coverage, GeneSetEnrichment, Alignment, QualityControl, ImmunoOncology

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -14,7 +14,7 @@ exportMethods(
     "sysargs", "outpaths", "show", "names", "length", "[", "catmap", "catlist", "idconv",
     "setlist", "intersectmatrix", "complexitylevels", "vennlist", "intersectlist",
     "as.list", "[[", "[[<-", "$", "clt", "cmdlist", "cwlfiles", "input", "inputvars", "output",
-    "SYSargs2list", "targets", "wf", "yamlinput", "SYSargs2Pipe_ls", "WF_steps", "track", "summaryWF"
+    "sysargs2", "targets", "wf", "yamlinput", "SYSargs2Pipe_ls", "WF_steps", "track", "summaryWF"
 )
 
 ## Functions
@@ -34,5 +34,6 @@ export(
     "preprocessReads", "filterVars", "variantReport", "combineVarReports", 
     "varSummary", "countRangeset", "runDiff", "genFeatures", "featuretypeCounts", 
     "plotfeaturetypeCounts", "featureCoverage", "plotfeatureCoverage", "predORF",
-    "scaleRanges", "loadWorkflow", "loadWF", "renderWF", "subsetWF", "output_update", "targets.as.df", "run_track", "olRanges", "createWF"
+    "scaleRanges", "loadWorkflow", "loadWF", "renderWF", "subsetWF", "output_update", 
+    "targets.as.df", "run_track", "olRanges", "createWF"
 )  

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,22 @@
+CHANGES IN VERSION 1.22
+-----------------------
+
+OVERVIEW
+    o systemPipeR major enhancements establish a versatile environment for designing, 
+    building and running end-to-end analysis workflows on local machines, 
+    HPC clusters, and cloud systems while generating at the same time publication-quality 
+    analysis reports.
+
+    o The most important enhancements in the upcoming release of the package are 
+      outlined below.  
+
+NEW FEATURES
+    o 
+
+BUG FIXES
+    o 
+
+
 CHANGES IN VERSION 1.3
 ----------------------
 

--- a/R/AllClasses2.R
+++ b/R/AllClasses2.R
@@ -55,8 +55,8 @@ setAs(from="list", to="SYSargs2",
 })
 
 ## Coerce back to list: as(SYSargs2, "list")
-setGeneric(name="SYSargs2list", def=function(x) standardGeneric("SYSargs2list"))
-setMethod(f="SYSargs2list", signature="SYSargs2", definition=function(x) {
+setGeneric(name="sysargs2", def=function(x) standardGeneric("sysargs2"))
+setMethod(f="sysargs2", signature="SYSargs2", definition=function(x) {
     sysargslist <- list(targets=x@targets, targetsheader=x@targetsheader, modules=x@modules, wf=x@wf, clt=x@clt, yamlinput=x@yamlinput, cmdlist=x@cmdlist, input=x@input, output=x@output, cwlfiles=x@cwlfiles, inputvars=x@inputvars)
 	return(sysargslist)
 }) 
@@ -64,7 +64,7 @@ setMethod(f="SYSargs2list", signature="SYSargs2", definition=function(x) {
 ## SYSargs2 to list with: as("SYSargs2", list)
 setAs(from="SYSargs2", to="list", 
 	def=function(from) {
-		SYSargs2list(from)
+		sysargs2(from)
 })
 
 ## Define print behavior for SYSargs2

--- a/R/AllClasses2.R
+++ b/R/AllClasses2.R
@@ -1190,8 +1190,8 @@ write.yml <- function(commandLine, file.yml, results_path, module_load){
 ## Define SYSargs2Pipe class
 setClass("SYSargs2Pipe", representation(
   WF_steps="list",
-  track="list", 
-  summaryWF="list") 
+  track="list",
+  summaryWF="list")
 )
 ## Methods to return SYSargs2Pipe components 
 setGeneric(name="WF_steps", def=function(x) standardGeneric("WF_steps"))
@@ -1224,11 +1224,12 @@ setAs(from="SYSargs2Pipe", to="list",
 
 ## Define print behavior for SYSargs2Pipe
 setMethod(f="show", signature="SYSargs2Pipe", 
-          definition=function(object) {    
+          definition=function(object) {
             cat(paste0("Instance of '", class(object), "':"), 
                 "   WF Instances:",
                 paste0("      ", seq_along(object@WF_steps), ". ", names(object@WF_steps)), 
                 "\n",  sep="\n")
+            warning("This class is deprecated. Use 'SYSargsList' instead. See help('SYSargs2-class) and help('Deprecated'')")
           })
 
 ## Extend names() method
@@ -1262,6 +1263,7 @@ setMethod(f="[[", signature="SYSargs2Pipe",
 ## Behavior of "$" operator for SYSargs2Pipe
 setMethod("$", signature="SYSargs2Pipe",
           definition=function(x, name) { 
+            .Deprecated(new="SYSargsList")
             slot(x, name)
           })
 
@@ -1276,6 +1278,7 @@ setReplaceMethod(f="[[", signature="SYSargs2Pipe", definition=function(x, i, j, 
 ## Run_track function ##
 ########################
 run_track <- function(WF_ls){
+  .Deprecated(new="initWF")
   if(any(class(WF_ls)!="list" & class(WF_ls[[1]])!="SYSargs2")) stop("Argument 'WF_steps' needs to be assigned a list of object of class 'SYSargs2'")
   ## Define workflows names in superlist
   namesWF <- as.character()

--- a/README
+++ b/README
@@ -1,5 +1,6 @@
 changelog
      version 1.21.07
+        - Replace name SYSargs2list methods to sysargs2 methods [Motivation: because we are introducing a new class called SYSargsList, to avoid any confusion]
         - BugFix: citation file
         - Updated News file
         

--- a/README
+++ b/README
@@ -1,4 +1,7 @@
 changelog
+     version 1.21.08
+        - Implementing deprecated for 'SYSargs2Pipe-class'; it will be replaced for 'SYSargsList'
+        
      version 1.21.07
         - Replace name SYSargs2list methods to sysargs2 methods [Motivation: because we are introducing a new class called SYSargsList, to avoid any confusion]
         - BugFix: citation file

--- a/README
+++ b/README
@@ -1,4 +1,8 @@
 changelog
+     version 1.21.07
+        - BugFix: citation file
+        - Updated News file
+        
      version 1.21.06
         - Fixed bug: 'runCommandline'
         - Internal functions for runCommandline(): modular and sustainable develp

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -1,3 +1,16 @@
-library(methods)
-library(knitcitations)
-bib_metadata("10.1186/s12859-016-1241-0")
+citEntry(entry="article",
+         title = "systemPipeR: NGS workflow and report generation environment",
+         author = personList( as.person("Tyler W. H. Backman"),
+                              as.person("Thomas Girke")),
+         year = 2016,
+         month = "sep",
+         publisher = "Springer Science and Business Media {LLC}",
+         journal = "BMC Bioinformatics",
+         doi = "10.1186/s12859-016-1241-0",
+         url = "https://doi.org/10.1186/s12859-016-1241-0",
+         volume = 17,
+         number = 1,
+         textVersion = 
+         paste("Backman TWH, Girke T (2016)", 
+               "systemPipeR: NGS workflow and report generation environment.",
+                "BMC Bioinformatics 17 (1), doi: 10.1186/s12859-016-1241-0."))

--- a/man/SYSargs2-class.Rd
+++ b/man/SYSargs2-class.Rd
@@ -20,7 +20,7 @@
 \alias{names,SYSargs2-method}
 \alias{output,SYSargs2-method}
 \alias{show,SYSargs2-method}
-\alias{SYSargs2list,SYSargs2-method}
+\alias{sysargs2,SYSargs2-method}
 \alias{targets,SYSargs2-method}
 \alias{targetsheader,SYSargs2-method}
 \alias{wf,SYSargs2-method}
@@ -67,7 +67,7 @@ Objects can be created by calls of the form \code{new("SYSargs2", ...)}.
     \item{names}{\code{signature(x = "SYSargs2")}: extracts slot names }
     \item{output}{\code{signature(x = "SYSargs2")}: extracts data from \code{cmdlist} slot }
     \item{show}{\code{signature(object = "SYSargs2")}: summary view of \code{SYSargs2} objects }
-    \item{SYSargs2list}{\code{signature(x = "SYSargs2")}: Coerce back to list \code{as(SYSargs2, "list")} }
+    \item{sysargs2}{\code{signature(x = "SYSargs2")}: Coerce back to list \code{as(SYSargs2, "list")} }
     \item{targets}{\code{signature(x = "SYSargs2")}: extract data from \code{targets} slot }
     \item{targetsheader}{\code{signature(x = "SYSargs2")}: extracts data from \code{targetsheader} slot }
     \item{wf}{\code{signature(x = "SYSargs2")}:  extracts data from \code{wf} slot }

--- a/man/SYSargs2Pipe-class.Rd
+++ b/man/SYSargs2Pipe-class.Rd
@@ -16,8 +16,9 @@
 \alias{track,SYSargs2Pipe-method}
 \alias{WF_steps,SYSargs2Pipe-method}
 
-\title{Class \code{"SYSargs2Pipe"}}
+\title{Deprecated \code{"SYSargs2Pipe"} Class}
 \description{
+This class and methods are deprecated and should be replaced by \code{SYSargsList} class and methods.
 \code{SYSargs2Pipe class} stores a list \code{SYSargs2} objects. Each \code{SYSargs2} objects stores all the information and instructions needed for processing a set of input files with a specific command-line or a series of command-line within a workflow. 
 }
 \section{Objects from the Class}{
@@ -50,12 +51,19 @@ Objects can be created by calls of the form \code{new("SYSargs2Pipe", ...)}.
 \author{
 Daniela Cassol and Thomas Girke
 }
+\details{
+  The following methods are deprecated and will be made defunct; use
+  the replacement indicated below:
+  \itemize{
+    \item{\code{SYSargs2Pipe}: \code{\link{SYSargs2-class}}}
+  }
+}
 \seealso{
 \code{loadWorkflow} and \code{renderWF} and \code{runCommandline} and \code{clusterRun}
 }
 \examples{
 showClass("SYSargs2Pipe")
-
+\dontrun{
 ## Construct SYSargs2 object from CWl param, CWL input, and targets files 
 targets <- system.file("extdata", "targets.txt", package="systemPipeR")
 dir_path <- system.file("extdata/cwl/hisat2/hisat2-se", package="systemPipeR")
@@ -69,5 +77,6 @@ WF_set <- run_track(WF_ls = c(WF))
 WF_steps(WF_set)
 track(WF_set)
 summaryWF(WF_set)[1]
+}
 }
 \keyword{ classes }

--- a/man/SYSargs2Pipe-methods.Rd
+++ b/man/SYSargs2Pipe-methods.Rd
@@ -8,9 +8,10 @@
 \alias{summaryWF}
 \alias{summaryWF-methods}
 \docType{data}
-\title{ SYSargs2Pipe accessor methods }                                  
+\title{Deprecated \code{"SYSargs2Pipe"} accessor methods}
 \description{
-	Methods to access information from \code{SYSargs2Pipe} object.
+These methods are deprecated and should be replaced by \code{SYSargsList-methods}.
+Methods to access information from \code{SYSargs2Pipe} object.
 }
 \usage{
 	SYSargs2Pipe_ls(x)
@@ -23,10 +24,17 @@
 \value{
 	various outputs
 }
+\details{
+The following methods are deprecated and will be made defunct; use the replacement indicated below:
+  \itemize{
+    \item{\code{SYSargs2Pipe}: \code{\link{SYSargs2-class}}}
+  }
+}
 \author{
 Daniela Cassol and Thomas Girke
 }
 \examples{
+\dontrun{
 ## Construct SYSargs2 object number 1
 targets <- system.file("extdata", "targets.txt", package="systemPipeR")
 dir_path <- system.file("extdata/cwl/hisat2/hisat2-se", package="systemPipeR")
@@ -48,5 +56,6 @@ WF_set <- run_track(WF_ls = c(WF1, WF))
 WF_steps(WF_set)
 track(WF_set)
 summaryWF(WF_set)[1]
+}
 }
 \keyword{ utilities }

--- a/man/run_track.Rd
+++ b/man/run_track.Rd
@@ -1,10 +1,10 @@
 \name{run_track}
 \alias{run_track}
 \title{
-Keep track of the all \code{SYSargs2} object
+Deprecated \code{run_track} functions
 }
 \description{
-Keep track of the all \code{SYSargs2} object.
+Keep track of the all \code{SYSargs2} object. This function is deprecated and should be replaced by \code{SYSargsList-class}.
 }
 \usage{
 run_track(WF_ls)
@@ -17,6 +17,13 @@ run_track(WF_ls)
 \value{
 \code{SYSargs2Pipe} object
 }
+\details{
+  The following methods are deprecated and will be made defunct; use
+  the replacement indicated below:
+  \itemize{
+    \item{\code{SYSargs2Pipe}: \code{\link{SYSargs2-class}}}
+  }
+}
 \author{
 Daniela Cassol and Thomas Girke}
 \seealso{
@@ -25,6 +32,7 @@ Daniela Cassol and Thomas Girke}
 \code{renderWF}
 }
 \examples{
+\dontrun{
 ## Construct SYSargs2 object number 1
 targets <- system.file("extdata", "targets.txt", package="systemPipeR")
 dir_path <- system.file("extdata/cwl/hisat2/hisat2-se", package="systemPipeR")
@@ -46,5 +54,6 @@ WF_set <- run_track(WF_ls = c(WF1, WF))
 WF_steps(WF_set)
 track(WF_set)
 summaryWF(WF_set)[1]
+}
 }
 \keyword{ utilities }

--- a/man/sysargs2-methods.Rd
+++ b/man/sysargs2-methods.Rd
@@ -1,6 +1,7 @@
-\name{SYSargs2list}
-\alias{SYSargs2list}
-\alias{SYSargs2list-method}
+\name{sysargs2}
+\docType{methods}
+\alias{sysargs2-method}
+\alias{sysargs2}
 \alias{targets}
 \alias{targets-methods}
 \alias{wf}
@@ -19,13 +20,13 @@
 \alias{cwlfiles-methods}
 \alias{inputvars}
 \alias{inputvars-methods}
-\docType{data}
+
 \title{ SYSargs2 accessor methods }                                  
 \description{
 	Methods to access information from \code{SYSargs2} object.
 }
 \usage{
-	SYSargs2list(x)
+	sysargs2(x)
 }
 \arguments{
   \item{x}{
@@ -47,5 +48,6 @@ WF <- loadWorkflow(targets=targets, wf_file="hisat2-mapping-se.cwl",
 WF <- renderWF(WF, inputvars=c(FileName="_FASTQ_PATH1_", SampleName="_SampleName_"))
 WF
 names(WF); modules(WF); targets(WF)[1]; cmdlist(WF)[1:2]; output(WF)
+sysargs2(WF)
 }
 \keyword{ utilities }

--- a/vignettes/systemPipeR.Rmd
+++ b/vignettes/systemPipeR.Rmd
@@ -39,7 +39,7 @@ knitr::opts_chunk$set(
     tidy.opts=list(width.cutoff=80), tidy=TRUE)
 ```
 
-```{r setup, echo=FALSE, messages=FALSE, warnings=FALSE}
+```{r setup, echo=FALSE, message=FALSE, warning=FALSE}
 suppressPackageStartupMessages({
     library(systemPipeR)
     library(BiocParallel)
@@ -274,7 +274,7 @@ them.
 ```{r targetsSE, eval=TRUE}
 library(systemPipeR)
 targetspath <- system.file("extdata", "targets.txt", package="systemPipeR") 
-read.delim(targetspath, comment.char = "#")
+read.delim(targetspath, comment.char = "#")[1:4,]
 ```
 
 To work with custom data, users need to generate a _`targets`_ file containing 

--- a/vignettes/systemPipeR_workflows.Rmd
+++ b/vignettes/systemPipeR_workflows.Rmd
@@ -42,15 +42,6 @@ knitr::opts_chunk$set(
 ```{r setup, echo=FALSE, messages=FALSE, warnings=FALSE}
 suppressPackageStartupMessages({
     library(systemPipeR)
-    library(BiocParallel)
-    library(Biostrings)
-    library(Rsamtools)
-    library(GenomicRanges)
-    library(ggplot2)
-    library(GenomicAlignments)
-    library(ShortRead)
-    library(ape)
-    library(batchtools)
 })
 ```
 


### PR DESCRIPTION
changelog

- version 1.21.08
```
- Implementing deprecated for 'SYSargs2Pipe-class'; it will be replaced for 'SYSargsList'
```

- version 1.21.07
```
- Replace name SYSargs2list methods to sysargs2 methods [Motivation: because we are introducing a new class called SYSargsList, to avoid any confusion]
- BugFix: citation file
- Updated News file
```



     
