### PR TITLE
Add timeout for tryCMD

### DIFF
--- a/R/sysargslist_utilities.R
+++ b/R/sysargslist_utilities.R
@@ -1672,7 +1672,7 @@ tryCMD <- function(command, silent = FALSE) {
     if (command == "gzip") command <- "gzip -h"
     tryCatch(
         {
-            system(command, ignore.stdout = TRUE, ignore.stderr = TRUE)
+            system(command, ignore.stdout = TRUE, ignore.stderr = TRUE, timeout = 2)
             if (!silent) print("All set, proceed!")
             if (silent) (return("proceed"))
         },


### PR DESCRIPTION
Commands like `bash` will hang if no other arguments given. Timeout force to return back to R prompt.