### PR TITLE
fix RCMD check error 

### DIFF
--- a/.github/workflows/R-CMD-build_check.yml
+++ b/.github/workflows/R-CMD-build_check.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           r-version: ${{ matrix.config.r }}
 
-      - uses: r-lib/actions/setup-pandoc@master
+      - uses: r-lib/actions/setup-pandoc@v2
 
       - name: Query dependencies
         run: |

--- a/.github/workflows/R-CMD-build_check.yml
+++ b/.github/workflows/R-CMD-build_check.yml
@@ -4,10 +4,10 @@
 on:
   push:
     branches:
-      - master
+      - devel
   pull_request:
     branches:
-      - master
+      - devel
 
 name: R-CMD-check
 

--- a/.github/workflows/R-CMD-build_check.yml
+++ b/.github/workflows/R-CMD-build_check.yml
@@ -22,9 +22,9 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: ubuntu-20.04, r: '4.1.3', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
-          - {os: macOS-latest, r: '4.1.3'}
-          - {os: windows-latest, r: '4.1.3'}  
+          - {os: ubuntu-20.04, r: '4.3.3', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
+          - {os: macOS-latest, r: '4.3.3'}
+          - {os: windows-latest, r: '4.3.3'}  
 
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,8 @@ Imports: GenomicRanges, SummarizedExperiment, ggplot2,
 Suggests: BiocStyle, knitr, rmarkdown, systemPipeRdata, GenomicAlignments, grid, 
             dplyr, testthat, rjson, annotate, AnnotationDbi, kableExtra, GO.db, 
             GenomeInfoDb, DT, rtracklayer, limma, edgeR, DESeq2, IRanges, 
-            batchtools, GenomicFeatures (>= 1.31.3), VariantAnnotation (>= 1.25.11)
+            batchtools, GenomicFeatures (>= 1.31.3), VariantAnnotation (>= 1.25.11),
+            txdbmaker 
 VignetteBuilder: knitr
 SystemRequirements: systemPipeR can be used to run external 
         command-line software (e.g. short read aligners), but the 

--- a/man/SYSargs2-class.Rd
+++ b/man/SYSargs2-class.Rd
@@ -82,7 +82,7 @@ Objects can be created by calls of the form \code{new("SYSargs2", ...)}.
     \item{\code{modules}:}{Object of class \code{"list"} storing software versions from module system }
     \item{\code{wf}:}{Object of class \code{"list"} storing data from Workflow \code{CWL parameters} file }
     \item{\code{clt}:}{Object of class \code{"list"} storing data from each \code{CommandLineTool}
-                        substep in the Workflow or the single code{CommandLineTool} \code{CWL parameters} file }
+                        substep in the Workflow or the single \code{CommandLineTool} \code{CWL parameters} file }
     \item{\code{yamlinput}:}{Object of class \code{"list"} storing data from \code{input (*.yml)} file }
     \item{\code{cmdlist}:}{Object of class \code{"list"} storing all command-line used to execute external software }
     \item{\code{input}:}{Object of class \code{"list"} storing data from each target defined in \code{inputvars} }

--- a/man/runDiff.Rd
+++ b/man/runDiff.Rd
@@ -36,7 +36,7 @@ runDiff(args, outfiles=NULL, diffFct, targets, cmp, dbrfilter, ...)
     targets \code{data.frame}
 }
   \item{cmp}{
-    code{character matrix} where comparisons are defined in two columns. This matrix should be generated with \code{readComp()} from the targets file. Values used for comparisons need to match those in the \code{Factor} column of the targets file.
+    \code{character matrix} where comparisons are defined in two columns. This matrix should be generated with \code{readComp()} from the targets file. Values used for comparisons need to match those in the \code{Factor} column of the targets file.
 }
   \item{dbrfilter}{
     Named vector with filter cutoffs of format \code{c(Fold=2, FDR=1)} where \code{Fold} refers to the fold change cutoff (unlogged) and \code{FDR} to the p-value cutoff. Those values are passed on to the \code{filterDEGs} function.

--- a/man/seeFastq.Rd
+++ b/man/seeFastq.Rd
@@ -16,7 +16,7 @@ instance, constant length clipping of the reads on either end or variable
 length clipping on the 3' end maintains this relationship, while variable
 length clipping on the 5' end without reversing the reads erases it.
 
-The function {seeFastq} computes the summary stats and stores them in a relatively 
+The function \code{seeFastq} computes the summary stats and stores them in a relatively 
 small list object that can be saved to disk with \code{save()} and reloaded with 
 \code{load()} for later plotting. The argument 'klength' specifies the k-mer length and 'batchsize' the
 number of reads to random sample from each fastq file.  }


### PR DESCRIPTION
As suggested in the check, one needs to add `txdbmaker` to make `makeTxDbFromGFF` work in 3.19. I added the package to suggests in DESCRIPTION, and it should fix the problem. I tried to check locally but failed because this seems to be a new package and only available on Bioc devel. 

Could merge and push to bioc and see if it pass the check over there?